### PR TITLE
fix: assures user data backwards compatibility

### DIFF
--- a/Model/FacebookAppModel.php
+++ b/Model/FacebookAppModel.php
@@ -244,7 +244,7 @@ class FacebookAppModel
 
         try
         {
-            $me = $this->facebook->api('/me');
+            $me = $this->facebook->api('/me?fields=first_name,gender,last_name,email,locale,name,timezone,updated_time,verified');
             $facebookData->setApiUser( new ApiUser($me) );
         }
         catch (\Exception $e)


### PR DESCRIPTION
The FB Graph API v. 2.2 returns all fields that are accessible without giving permissions.
Since 2.3 you have to explicitly name those fields in the query parameter. In order to ensure backwards compatibility, we specify all fields that are available without user permissions.

Check out https://developers.facebook.com/tools/explorer?method=GET&path=me&version=v2.2 to see the differences between v2.2 and v2.5
